### PR TITLE
Undefined handling on initial draw

### DIFF
--- a/tesla-style-solar-power-card.js
+++ b/tesla-style-solar-power-card.js
@@ -524,7 +524,7 @@ class TeslaStyleSolarPowerCard extends HTMLElement {
     var delta = entity.speed * timePassed;
     entity.currentDelta += delta;
     let percentageDelta = entity.currentDelta / lineLength;
-    if (percentageDelta >= 1) {
+    if (percentageDelta >= 1 || isNaN(percentageDelta)) {
       entity.currentDelta = 0;
       percentageDelta = 0.01;
     }


### PR DESCRIPTION
Added in handling of an undefined value for percentageDelta on initial draw.  I would see the card not render correctly under certain scenarios.  