### PR TITLE
Include info on using with Tesla Powerwall

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ hide_inactive_lines: 1
 ### Tesla Powerwall Usage
 In order to use this card with the [Tesla Powerwall integration](https://www.home-assistant.io/integrations/powerwall/) you will need to create some additional sensors first. This card expects an entity with a positive numeric value per line shown on the screen. However the Tesla Powerwall integration creates sensors which go negative or positive depending on whether energy is being consumed from or feed into that particular meter. 
 
-Fortunately this can be easily fixed with the addition of a few template sensors. Here's the sensors you would need to add. Note that these sensors assume the default names for each entity created Powerwall integration, if you've changed the names of your entities then you'll need to adjust the config accordingly:
+Fortunately this can be easily fixed with the addition of a few template sensors, the ones you would need to add are shown below. Note that these sensors assume the default names for each entity created by the Tesla Powerwall integration, if you've changed the names of your entities then you'll need to adjust the config accordingly:
 ```yaml
 - platform: template
   sensors:


### PR DESCRIPTION
Added a section to the readme on how to use the card with the Tesla Powerwall integration. Since the card design is based on the Tesla Powerwall UI it seems likely that users of that integraiton would come across it and try and use it.

Like the user in https://github.com/reptilex/tesla-style-solar-power-card/issues/20, I had a difficult time figuring out how the powerwall entities translated to it. I think I have it figured out so thought I would help out future users by updating the doc with that info.

If you think the readme is the wrong place for this let me know what you'd prefer. I know you said in that issue that you don't actually use Tesla Powerwall so I'd understand if you don't want Tesla Powerwall specific stuff in the Readme. Contents could be moved to a separate doc for Tesla powerwall users or somewhere else if you prefer.